### PR TITLE
fix: add connection_limit parameter to Prisma database URL

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,8 +1,11 @@
 # Database Configuration
 # PostgreSQL with pgvector extension for vector similarity search
+# Note: connection_limit will be automatically appended to the URL based on DB_POOL_SIZE
 DATABASE_URL="postgresql://perrache:perrache_dev_password@localhost:5432/perrache?schema=public"
 
-# Database Connection Pool Size (optional, defaults to Prisma's internal pool)
+# Database Connection Pool Size (optional, defaults to 10)
+# This value is automatically added as 'connection_limit' parameter to the DATABASE_URL
+# You can also specify connection_limit directly in DATABASE_URL to override this setting
 DB_POOL_SIZE=10
 
 # Rate Limiting

--- a/apps/api/src/lib/db.ts
+++ b/apps/api/src/lib/db.ts
@@ -7,15 +7,35 @@ import { PrismaClient } from '@prisma/client'
 class DatabaseService {
   private static instance: PrismaClient | null = null
 
+  /**
+   * Builds the database URL with connection_limit parameter for Prisma
+   * Prisma uses connection_limit in the URL to configure pool size
+   */
+  private static buildDatabaseUrl(): string {
+    const baseUrl = process.env.DATABASE_URL || ''
+    const poolSize = parseInt(process.env.DB_POOL_SIZE || '10', 10)
+
+    // Parse the URL to add connection_limit parameter
+    const url = new URL(baseUrl)
+
+    // Only set connection_limit if not already present in the URL
+    if (!url.searchParams.has('connection_limit')) {
+      url.searchParams.set('connection_limit', poolSize.toString())
+    }
+
+    return url.toString()
+  }
+
   static getInstance(): PrismaClient {
     if (!DatabaseService.instance) {
       const poolSize = parseInt(process.env.DB_POOL_SIZE || '10', 10)
+      const databaseUrl = DatabaseService.buildDatabaseUrl()
 
       DatabaseService.instance = new PrismaClient({
         log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
         datasources: {
           db: {
-            url: process.env.DATABASE_URL
+            url: databaseUrl
           }
         }
       })


### PR DESCRIPTION
Prisma doesn't use custom pool size options passed to PrismaClient. Instead, it requires the connection_limit parameter to be set directly in the DATABASE_URL query string.

This change:
- Adds buildDatabaseUrl() method to append connection_limit based on DB_POOL_SIZE
- Respects existing connection_limit if already set in DATABASE_URL
- Updates .env.example documentation to explain the behavior

Closes #2

Co-authored-by: Mauro Murru <brainrepo@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)