### PR TITLE
fix: replace deprecated request.routerPath with request.routeOptions.url

### DIFF
--- a/apps/api/src/plugins/metrics.ts
+++ b/apps/api/src/plugins/metrics.ts
@@ -35,13 +35,13 @@ async function metricsPlugin(fastify: FastifyInstance): Promise<void> {
   // Track request metrics on response
   fastify.addHook('onResponse', (request, reply, done) => {
     // Skip metrics collection for excluded paths
-    const path = request.routerPath || request.url
+    const path = request.routeOptions.url || request.url
     if (excludePaths.some((excludePath) => path.startsWith(excludePath))) {
       done()
       return
     }
 
-    const route = request.routerPath || request.url
+    const route = request.routeOptions.url || request.url
     const method = request.method
     const statusCode = reply.statusCode.toString()
 


### PR DESCRIPTION
Closes #4

Replaces the deprecated `request.routerPath` (removed in Fastify v5) with `request.routeOptions.url` in the metrics plugin.

Generated with [Claude Code](https://claude.ai/code)