### PR TITLE
feat: expose Prisma database metrics via /metrics endpoint

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["postgresqlExtensions"]
+  previewFeatures = ["postgresqlExtensions", "metrics"]
 }
 
 datasource db {

--- a/apps/api/src/lib/db.ts
+++ b/apps/api/src/lib/db.ts
@@ -64,6 +64,21 @@ class DatabaseService {
       return false
     }
   }
+
+  /**
+   * Get Prisma metrics in Prometheus format
+   * Requires the 'metrics' preview feature to be enabled in schema.prisma
+   * @returns Prometheus-formatted metrics string
+   */
+  static async getMetrics(): Promise<string> {
+    const db = DatabaseService.getInstance()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = db as any
+    if (typeof client.$metrics?.prometheus === 'function') {
+      return client.$metrics.prometheus()
+    }
+    return ''
+  }
 }
 
 export const db = DatabaseService.getInstance()

--- a/apps/api/src/plugins/metrics.ts
+++ b/apps/api/src/plugins/metrics.ts
@@ -1,6 +1,7 @@
 import fp from 'fastify-plugin'
 import { FastifyInstance } from 'fastify'
 import client from 'prom-client'
+import { DatabaseService } from '../lib/db'
 
 // Create a custom registry to avoid polluting the global registry
 const register = new client.Registry()
@@ -61,7 +62,18 @@ async function metricsPlugin(fastify: FastifyInstance): Promise<void> {
   // Register /metrics endpoint
   fastify.get('/metrics', async (request, reply) => {
     reply.header('Content-Type', register.contentType)
-    return register.metrics()
+
+    // Get prom-client metrics
+    const promMetrics = await register.metrics()
+
+    // Get Prisma database metrics (if available)
+    const prismaMetrics = await DatabaseService.getMetrics()
+
+    // Combine both metrics outputs
+    // Prisma metrics are already in Prometheus format
+    const combinedMetrics = prismaMetrics ? `${promMetrics}\n${prismaMetrics}` : promMetrics
+
+    return combinedMetrics
   })
 }
 


### PR DESCRIPTION
Exposes Prisma database metrics via client.$metrics.prometheus() in the /metrics endpoint as requested in #5.

**Changes:**
- Enable metrics preview feature in Prisma schema
- Add DatabaseService.getMetrics() method
- Integrate Prisma metrics into existing /metrics endpoint

Closes #5

Generated with [Claude Code](https://claude.ai/code)